### PR TITLE
Solidity challenge

### DIFF
--- a/solidity/contracts/interfaces/IBlockHashOracle.sol
+++ b/solidity/contracts/interfaces/IBlockHashOracle.sol
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+pragma solidity >=0.8.0;
+
+interface IBlockHashOracle {
+    // uint32 public immutable origin;
+    function origin() external view returns (uint32);
+
+    // function blockhash(uint256 height) external view returns (uint256 hash);
+    function getBlockhash(uint256 height) external view returns (uint256 hash);
+}

--- a/solidity/contracts/interfaces/IInterchainSecurityModule.sol
+++ b/solidity/contracts/interfaces/IInterchainSecurityModule.sol
@@ -14,7 +14,8 @@ interface IInterchainSecurityModule {
         ARB_L2_TO_L1,
         WEIGHTED_MERKLE_ROOT_MULTISIG,
         WEIGHTED_MESSAGE_ID_MULTISIG,
-        OP_L2_TO_L1
+        OP_L2_TO_L1,
+        BLOCK_HASH
     }
 
     /**

--- a/solidity/contracts/isms/block-hash/BlockHashIsm.sol
+++ b/solidity/contracts/isms/block-hash/BlockHashIsm.sol
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+pragma solidity >=0.8.0;
+
+// ============ Internal Imports ============
+import {IInterchainSecurityModule} from "../../interfaces/IInterchainSecurityModule.sol";
+import {IBlockHashOracle} from "../../interfaces/IBlockHashOracle.sol";
+import {Address} from "@openzeppelin/contracts/utils/Address.sol";
+import {Message} from "../../libs/Message.sol";
+import {Mailbox} from "../../Mailbox.sol";
+
+contract BlockHashIsm is IInterchainSecurityModule {
+    using Message for bytes;
+
+    uint8 public immutable moduleType = uint8(Types.BLOCK_HASH);
+    Mailbox public immutable mailbox;
+    IBlockHashOracle public immutable blockHashOracle;
+    address public immutable trustedRelayer;
+
+    constructor(
+        address _mailbox,
+        address _trustedRelayer,
+        address _blockHashOracle
+    ) {
+        require(_trustedRelayer != address(0), "BlockHashIsm: invalid relayer");
+        require(Address.isContract(_mailbox), "BlockHashIsm: invalid mailbox");
+        require(
+            Address.isContract(_blockHashOracle),
+            "BlockHashIsm: invalid blockHashOracle"
+        );
+        mailbox = Mailbox(_mailbox);
+        blockHashOracle = IBlockHashOracle(_blockHashOracle);
+        trustedRelayer = _trustedRelayer;
+    }
+
+    function verify(
+        bytes calldata _metadata,
+        bytes calldata _message
+    ) external view override returns (bool) {
+        // is the relayer trusted?
+        bool isTrustedRelayer = mailbox.processor(_message.id()) ==
+            trustedRelayer;
+
+        // is the origin in the message equals to origin from the oracle?
+        bool isOriginCorrect = _message.origin() ==
+            IBlockHashOracle(blockHashOracle).origin();
+
+        // is the hash returned by the oracle same of the one included in the metadata?
+        (uint256 blockHeight, bytes32 messageHash) = abi.decode(
+            _metadata,
+            (uint256, bytes32)
+        );
+
+        bool isBlockHashCorrect = blockHashOracle.getBlockhash(blockHeight) ==
+            uint256(messageHash);
+
+        return isTrustedRelayer && isOriginCorrect && isBlockHashCorrect;
+    }
+}

--- a/solidity/test/isms/BlockHashIsm.t.sol
+++ b/solidity/test/isms/BlockHashIsm.t.sol
@@ -1,0 +1,198 @@
+// SPDX-License-Identifier: MIT or Apache-2.0
+pragma solidity ^0.8.13;
+
+import {Test, console2} from "forge-std/Test.sol";
+
+import {IBlockHashOracle} from "../../contracts/interfaces/IBlockHashOracle.sol";
+
+import {TestMailbox} from "../../contracts/test/TestMailbox.sol";
+import {TestRecipient} from "../../contracts/test/TestRecipient.sol";
+
+import {TypeCasts} from "../../contracts/libs/TypeCasts.sol";
+import {BlockHashIsm} from "../../contracts/isms/block-hash/BlockHashIsm.sol";
+
+/// @notice to run tests:
+/// forge test --match-path ./test/isms/BlockHashIsm.t.sol
+/// forge test --match-path ./test/isms/BlockHashIsm.t.sol --match-test test_verify_success
+
+contract BlockHashIsmTest is Test {
+    using TypeCasts for address;
+
+    uint32 localDomain = 12345;
+    uint32 remoteDomain = 54321;
+    uint32 origin = 1;
+
+    TestMailbox mailbox;
+    BlockHashIsm ism;
+    TestRecipient recipient;
+    MockBlockHashOracle oracle;
+
+    address relayer;
+
+    function setUp() public {
+        relayer = msg.sender;
+        recipient = new TestRecipient();
+        mailbox = new TestMailbox(12345);
+        oracle = new MockBlockHashOracle(origin);
+        ism = new BlockHashIsm(address(mailbox), relayer, address(oracle));
+        recipient.setInterchainSecurityModule(address(ism));
+    }
+
+    function test_revertsWhen_invalidInputParams() public {
+        vm.expectRevert("BlockHashIsm: invalid relayer");
+        new BlockHashIsm(address(mailbox), address(0), address(oracle));
+        vm.expectRevert("BlockHashIsm: invalid mailbox");
+        new BlockHashIsm(relayer, relayer, address(oracle));
+        vm.expectRevert("BlockHashIsm: invalid blockHashOracle");
+        new BlockHashIsm(address(mailbox), relayer, address(1));
+    }
+
+    function test_verify_success(
+        uint256 height,
+        bytes32 sender,
+        bytes calldata body
+    ) public {
+        // creating the msg
+        bytes memory message = mailbox.buildInboundMessage(
+            origin,
+            address(recipient).addressToBytes32(),
+            sender,
+            body
+        );
+
+        bytes32 computedHash = keccak256(
+            abi.encodePacked(
+                height,
+                block.chainid,
+                address(oracle),
+                block.timestamp
+            )
+        );
+
+        // setting the hash and the id in our oracle
+        oracle.setBlockhash(height, computedHash);
+
+        bytes memory metadata = abi.encodePacked(height, computedHash);
+
+        vm.prank(relayer);
+        mailbox.process(metadata, message);
+        assertTrue(ism.verify(metadata, message));
+    }
+
+    function test_RevertIf_isNotTrustedRelayer(
+        uint256 height,
+        bytes32 sender,
+        bytes calldata body
+    ) public {
+        // creating the msg
+        bytes memory message = mailbox.buildInboundMessage(
+            origin,
+            address(recipient).addressToBytes32(),
+            sender,
+            body
+        );
+
+        bytes32 computedHash = keccak256(
+            abi.encodePacked(
+                height,
+                block.chainid,
+                address(oracle),
+                block.timestamp
+            )
+        );
+        // setting the hash in our mock oracle
+        oracle.setBlockhash(height, computedHash);
+
+        bytes memory metadata = abi.encodePacked(height, computedHash);
+
+        vm.expectRevert("Mailbox: ISM verification failed");
+        mailbox.process(metadata, message);
+        assertFalse(ism.verify(metadata, message));
+    }
+
+    function test_RevertIf_originIsNotCorrect(
+        uint256 height,
+        bytes32 sender,
+        bytes calldata body
+    ) public {
+        // creating the msg
+        bytes memory message = mailbox.buildInboundMessage(
+            2,
+            address(recipient).addressToBytes32(),
+            sender,
+            body
+        );
+
+        bytes32 computedHash = keccak256(
+            abi.encodePacked(
+                height,
+                block.chainid,
+                address(oracle),
+                block.timestamp
+            )
+        );
+        // setting the hash in our mock oracle
+        oracle.setBlockhash(height, computedHash);
+
+        bytes memory metadata = abi.encodePacked(height, computedHash);
+
+        vm.expectRevert("Mailbox: ISM verification failed");
+        mailbox.process(metadata, message);
+        assertFalse(ism.verify(metadata, message));
+    }
+
+    function test_RevertIf_hashesDontMatch(
+        uint256 height,
+        bytes32 sender,
+        bytes calldata body
+    ) public {
+        // creating the msg
+        bytes memory message = mailbox.buildInboundMessage(
+            origin,
+            address(recipient).addressToBytes32(),
+            sender,
+            body
+        );
+
+        bytes32 computedHash = keccak256(
+            abi.encodePacked(
+                height,
+                block.chainid,
+                address(oracle),
+                block.timestamp
+            )
+        );
+        // setting the hash in our mock oracle
+        oracle.setBlockhash(height, computedHash);
+        // computing the hash to compare to the one on the oracle
+
+        bytes memory metadata = abi.encodePacked(height, computedHash);
+
+        vm.expectRevert("Mailbox: ISM verification failed");
+        mailbox.process(metadata, message);
+        assertFalse(ism.verify(metadata, message));
+    }
+}
+
+contract MockBlockHashOracle is IBlockHashOracle {
+    uint32 private immutable _origin;
+    mapping(uint256 => uint256) private _blockHashes;
+
+    constructor(uint32 origin_) {
+        _origin = origin_;
+    }
+
+    function origin() external view override returns (uint32) {
+        return _origin;
+    }
+
+    function getBlockhash(
+        uint256 height
+    ) external view override returns (uint256 hash) {
+        return _blockHashes[height];
+    }
+
+    function setBlockhash(uint256 height, bytes32 hash) external {
+        _blockHashes[height] = uint256(hash);
+    }
+}


### PR DESCRIPTION
### Description

This PR contains the `BlockHashIsm` module. It's needed to verify that a message was dispatched from an origin chain. 
It uses `IBlockHashOracle` to check that the origin and the hash in the oracle are the same contained in message and metadata.


### Testing
To run tests, enter the `solidity folder` and run:
```
forge test --match-path ./test/isms/BlockHashIsm.t.sol
```

